### PR TITLE
Update proto3 isOptional check condition

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -185,7 +185,7 @@ function isEnum(fieldDescriptor) {
  */
 function isOptional(rootDescriptor, fieldDescriptor) {
     if (rootDescriptor.syntax == "proto3") {
-        return fieldDescriptor.label != descriptor.FieldDescriptorProto.Label.LABEL_REQUIRED || fieldDescriptor.proto3_optional
+        return fieldDescriptor.proto3_optional
     }
     return fieldDescriptor.label == descriptor.FieldDescriptorProto.Label.LABEL_OPTIONAL;
 }


### PR DESCRIPTION
Latest `proto3` already supports `optional` by default. Using `proto3_optional` to improve type safe constructors.
This feature might not be suitable for everyone, because this is what Google wants to avoid.
But it does improve the type check.